### PR TITLE
Link origin story to X post and update footer notice

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -43,7 +43,9 @@ const Footer = () => {
         </div>
         
         <div className="border-t border-arlos-blue/20 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center gap-4 text-muted-foreground">
-          <p className="text-lg">&copy; 2025 ARLOS.pro. The future of work is outcome-driven.</p>
+          <p className="text-lg text-center md:text-left">
+            &copy; 2025 GSD at Work LLC. All rights reserved.
+          </p>
           <Link
             to="/origin-story"
             className="text-sm hover:text-arlos-blue transition-colors duration-300 hover:scale-105 inline-block opacity-75 hover:opacity-100"

--- a/src/pages/OriginStory.tsx
+++ b/src/pages/OriginStory.tsx
@@ -10,12 +10,23 @@ const OriginStory = () => (
         ARLOS emerged from a desire to coordinate work through clear outcomes rather than traditional hierarchies.
         By combining prediction markets with aligned incentives, the framework offers a new model for collaborative execution.
       </p>
-      <p className="mb-4 text-muted-foreground">
-        The concept was first explored in 2024 and has since evolved through community feedback and real-world experiments.
-        Hosting the story here ensures anyone can learn about the motivation behind ARLOS without needing a social media account.
+      <p className="mb-6 text-muted-foreground">
+        The first public sketch of the protocol lives in an X (Twitter) post that set the tone for what ARLOS could become.
+        You can read that opening thought here:
+        {" "}
+        <a
+          href="https://x.com/curious_vii/status/1952434140411748727?s=46"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-arlos-blue underline underline-offset-4"
+        >
+          Origin tweet by @curious_vii
+        </a>
+        .
       </p>
       <p className="mb-4 text-muted-foreground">
-        This page preserves the origin story without relying on any external platforms.
+        Everything since has been an exploration of how to turn that spark into a resilient, crypto-native coordination protocol.
+        This space will continue to document the evolution so it remains accessible without needing a social media account.
       </p>
     </main>
     <Footer />


### PR DESCRIPTION
## Summary
- link the origin story page to the original X/Twitter post that kicked off ARLOS
- refresh the on-page copy so it explains the tweet’s significance and future documentation plans
- update the footer copyright line to credit GSD at Work LLC with all rights reserved

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d9966fe214833388e5bc3b26f2ce31